### PR TITLE
adds review id in vocab response if one exists.

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -295,7 +295,7 @@ class UserViewSet(viewsets.GenericViewSet, generics.ListCreateAPIView):
         if self.request.user.is_staff:
             return User.objects.all()
 
-        return User.objects.filter(pk=self.request.user.id)
+        return User.objects.get(pk=self.request.user.id)
 
     @list_route(methods=["GET", "PUT"])
     def me(self, request):

--- a/kw_webapp/tests/test_profile_api.py
+++ b/kw_webapp/tests/test_profile_api.py
@@ -269,5 +269,18 @@ class TestProfileApi(APITestCase):
         response = self.client.get(reverse("api:review-lesson"))
         self.assertEqual(response.data["count"], 0)
 
+    def test_vocabulary_view_returns_related_review_id_if_present(self):
+        self.client.force_login(user=self.user)
+
+        response = self.client.get(reverse("api:vocabulary-detail", args=(self.review.vocabulary.id,)))
+
+        self.assertEqual(response.data['review'], self.review.id)
+
+    def test_review_views_nested_vocabulary_omits_review_field(self):
+        self.client.force_login(user=self.user)
+
+        response = self.client.get(reverse("api:review-detail", args=(self.review.id,)))
+
+        self.assertTrue('review' not in response.data['vocabulary'])
 
 

--- a/out.html
+++ b/out.html
@@ -1,0 +1,1 @@
+{"id":369,"meaning":"to understand","readings":[{"id":392,"character":"分かる","kana":"わかる","level":3,"tags":["Intransitive verb","Godan verb"],"sentence_en":"“Got it?” “Yes”","sentence_ja":"「分かった？」「はい」","jlpt":"JLPT N5","common":true}],"review":239}


### PR DESCRIPTION
Closes #320 

* If getting `/vocabulary`, we add `{'review': id}` as part of the vocab response, for easy fetching. 
* If getting `/review/`, we omit this field in the nested vocabulary object. 