### PR TITLE
Task/317 add level param to reset

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -345,7 +345,8 @@ class UserViewSet(viewsets.GenericViewSet, generics.ListCreateAPIView):
 
     @list_route(methods=['POST'])
     def reset(self, request):
-        reset_user(request.user)
+        reset_to_level = int(request.data['level']) if 'level' in request.data else None
+        reset_user(request.user, reset_to_level)
         return Response({"message": "Your account has been reset"})
 
 

--- a/kw_webapp/tests/test_profile_api.py
+++ b/kw_webapp/tests/test_profile_api.py
@@ -283,4 +283,25 @@ class TestProfileApi(APITestCase):
 
         self.assertTrue('review' not in response.data['vocabulary'])
 
+    def test_adding_a_level_to_reset_command_only_resets_levels_above_given(self):
+        self.client.force_login(user=self.user)
+        v = create_vocab("test")
+        create_reading(v, "test", "test", 3)
+        create_userspecific(v, self.user)
+        self.user.profile.unlocked_levels.get_or_create(level=3)
+        response = self.client.get((reverse("api:review-current")))
+        self.assertEqual(response.data['count'], 2)
+        self.assertListEqual(self.user.profile.unlocked_levels_list(), [5,3])
+        self.client.post(reverse("api:user-reset"), data={'level': 3})
+
+        response = self.client.get((reverse("api:review-current")))
+        self.assertEqual(response.data['count'], 1)
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.level, 3)
+        self.assertListEqual(self.user.profile.unlocked_levels_list(), [3])
+
+
+
+
+
 


### PR DESCRIPTION
* Adds post param `level` to `/api/v1/user/reset` endpoint. 
* This is to accomodate the new WK "reset down to level X" functionality.

There are two possible scenarios: 
1) The user includes a level. In this case, we simply clear all levels above that, and delete all reviews which do not contain a reading with a level below the threshold. 
2) The user does not include a level. In this case, we clear all levels, delete all reviews, and re-unlock the level that the user is currently at on Wanikani.