### PR TITLE
Task/347 notes to meaning

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -1,8 +1,9 @@
 from django.conf.urls import url, include
 from rest_framework.routers import DefaultRouter
 from rest_framework_jwt import views as jwtviews
-from api.views import ReviewViewSet, VocabularyViewSet, ReadingViewSet, LevelViewSet, SynonymViewSet, \
-    FrequentlyAskedQuestionViewSet, AnnouncementViewSet, UserViewSet, ContactViewSet, ProfileViewSet, ReportViewSet
+from api.views import ReviewViewSet, VocabularyViewSet, ReadingViewSet, LevelViewSet, ReadingSynonymViewSet, \
+    FrequentlyAskedQuestionViewSet, AnnouncementViewSet, UserViewSet, ContactViewSet, ProfileViewSet, ReportViewSet, \
+    MeaningSynonymViewSet
 
 router = DefaultRouter()
 router.register(r'review', ReviewViewSet, base_name="review")
@@ -10,7 +11,8 @@ router.register(r'vocabulary', VocabularyViewSet, base_name="vocabulary")
 router.register(r'report', ReportViewSet, base_name="report")
 router.register(r'reading', ReadingViewSet, base_name="reading")
 router.register(r'level', LevelViewSet, base_name="level")
-router.register(r'synonym', SynonymViewSet, base_name="synonym")
+router.register(r'synonym/reading', ReadingSynonymViewSet, base_name="reading-synonym")
+router.register(r'synonym/meaning', MeaningSynonymViewSet, base_name="meaning-synonym")
 router.register(r'faq', FrequentlyAskedQuestionViewSet, base_name='faq')
 router.register(r'announcement', AnnouncementViewSet, base_name='announcement')
 router.register(r'user', UserViewSet, base_name='user')

--- a/api/views.py
+++ b/api/views.py
@@ -14,13 +14,13 @@ from rest_framework.viewsets import ModelViewSet
 from api.filters import VocabularyFilter, ReviewFilter
 from api.permissions import IsAdminOrReadOnly, IsAuthenticatedOrCreating
 from api.serializers import ReviewSerializer, VocabularySerializer, StubbedReviewSerializer, \
-    HyperlinkedVocabularySerializer, ReadingSerializer, LevelSerializer, SynonymSerializer, \
+    HyperlinkedVocabularySerializer, ReadingSerializer, LevelSerializer, ReadingSynonymSerializer, \
     FrequentlyAskedQuestionSerializer, AnnouncementSerializer, UserSerializer, ContactSerializer, ProfileSerializer, \
-    ReportSerializer, ReportCountSerializer, ReportListSerializer
+    ReportSerializer, ReportCountSerializer, ReportListSerializer, MeaningSynonymSerializer
 from kw_webapp import constants
 from kw_webapp.forms import UserContactCustomForm
 from kw_webapp.models import Vocabulary, UserSpecific, Reading, Level, AnswerSynonym, FrequentlyAskedQuestion, \
-    Announcement, Profile, Report
+    Announcement, Profile, Report, MeaningSynonym
 from kw_webapp.tasks import get_users_current_reviews, unlock_eligible_vocab_from_levels, lock_level_for_user, \
     get_users_critical_reviews, sync_with_wk, all_srs, sync_user_profile_with_wk, user_returns_from_vacation, \
     user_begins_vacation, follow_user, reset_user, get_users_lessons
@@ -45,14 +45,18 @@ class ReadingViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ReadingSerializer
 
 
-class SynonymViewSet(viewsets.ModelViewSet):
-    serializer_class = SynonymSerializer
+class ReadingSynonymViewSet(viewsets.ModelViewSet):
+    serializer_class = ReadingSynonymSerializer
 
     def get_queryset(self):
         return AnswerSynonym.objects.filter(review__user=self.request.user)
 
-    def create(self, request, *args, **kwargs):
-        return super().create(request, *args, **kwargs)
+
+class MeaningSynonymViewSet(viewsets.ModelViewSet):
+    serializer_class = MeaningSynonymSerializer
+
+    def get_queryset(self):
+        return MeaningSynonym.objects.filter(review__user=self.request.user)
 
 
 class LevelViewSet(viewsets.ReadOnlyModelViewSet):
@@ -289,7 +293,9 @@ class ReviewViewSet(ListRetrieveUpdateViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def get_queryset(self):
-      return UserSpecific.objects.filter(user=self.request.user, wanikani_srs_numeric__gte=self.request.user.profile.get_minimum_wk_srs_threshold_for_review())
+        return UserSpecific.objects.filter(user=self.request.user,
+                                           wanikani_srs_numeric__gte=self.request.user.profile.get_minimum_wk_srs_threshold_for_review())
+
 
 class FrequentlyAskedQuestionViewSet(viewsets.ModelViewSet):
     """

--- a/kw_webapp/models.py
+++ b/kw_webapp/models.py
@@ -260,7 +260,7 @@ class UserSpecific(models.Model):
         return ", ".join([synonym.text for synonym in self.meaningsynonym_set.all()])
 
     def remove_synonym(self, text):
-        self.meaningsynonym_set.remove(MeaningSynonym.objects.get(text=text))
+        MeaningSynonym.objects.get(text=text).delete()
 
     def answer_synonyms_list(self):
         return [synonym.kana for synonym in self.answer_synonyms.all()]

--- a/kw_webapp/tests/test_meaningsynonym_api.py
+++ b/kw_webapp/tests/test_meaningsynonym_api.py
@@ -1,0 +1,63 @@
+import json
+import pprint
+from datetime import timedelta
+from time import sleep
+from unittest import mock
+
+from django.utils import timezone
+from rest_framework.renderers import JSONRenderer
+from rest_framework.reverse import reverse, reverse_lazy
+from rest_framework.test import APITestCase
+
+from kw_webapp.constants import WkSrsLevel, WANIKANI_SRS_LEVELS
+from kw_webapp.models import Level, Report, Announcement
+from kw_webapp.tests.utils import create_user, create_profile, create_vocab, create_reading, create_userspecific, \
+    create_review_for_specific_time
+from kw_webapp.utils import one_time_orphaned_level_clear
+
+
+class TestMeaningSynonymApi(APITestCase):
+    def setUp(self):
+        self.user = create_user("Tadgh")
+        create_profile(self.user, "any_key", 5)
+        self.vocabulary = create_vocab("radioactive bat")
+        self.reading = create_reading(self.vocabulary, "ねこ", "猫", 5)
+        self.review = create_userspecific(self.vocabulary, self.user)
+
+    def test_user_can_CRUD_all_their_own_synonyms(self):
+        self.client.force_login(self.user)
+
+        # Create
+        synonym = {
+            'review': self.review.id,
+            'text': "My fancy synonym"
+        }
+        response = self.client.post(reverse("api:meaning-synonym-list"), data=synonym)
+        self.assertEqual(response.status_code, 201)
+
+        # Read
+        self.assertEqual(self.review.synonyms_string(), "My fancy synonym")
+        response = self.client.get(reverse("api:meaning-synonym-list"))
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+        synonym = data['results'][0]
+        self.assertEqual(len(data['results']), 1)
+
+        # Update
+        synonym['text'] = "A different fancy synonym"
+        response = self.client.put(reverse("api:meaning-synonym-detail", args=(synonym["id"],)), data=synonym)
+
+        self.assertEqual(response.status_code, 200)
+        # Double check update worked...
+        self.review.refresh_from_db()
+        self.assertEqual(self.review.synonyms_string(), "A different fancy synonym")
+        self.assertEqual(len(self.review.synonyms_list()), 1)
+
+        # Delete
+        self.client.delete(reverse("api:meaning-synonym-detail", args=(synonym["id"],)))
+        self.review.refresh_from_db()
+        self.assertEqual(len(self.review.synonyms_list()), 0)
+
+
+
+

--- a/kw_webapp/tests/test_profile_api.py
+++ b/kw_webapp/tests/test_profile_api.py
@@ -211,7 +211,7 @@ class TestProfileApi(APITestCase):
         self.client.force_login(user=self.user)
         synonym_kana = "いぬ"
         synonym_kanji = "犬"
-        s1 = reverse("api:synonym-list")
+        s1 = reverse("api:reading-synonym-list")
         response = self.client.get(s1)
         self.assertEqual(response.data['count'], 0)
 


### PR DESCRIPTION
This is for task #347, which was originally to change the _notes_ field to _custom_meaning_ field, however, we already had a custom meaning field, so i just went ahead and exposed that information via a standard CRUD endpoint. Changes to URLs though: 

```python
router.register(r'synonym/reading', ReadingSynonymViewSet, base_name="reading-synonym")
router.register(r'synonym/meaning', MeaningSynonymViewSet, base_name="meaning-synonym")
```