### PR TITLE
correctly switch api_valid to false.

### DIFF
--- a/kw_webapp/tasks.py
+++ b/kw_webapp/tasks.py
@@ -273,7 +273,7 @@ def sync_with_wk(user_id, full_sync=False):
     user = User.objects.get(pk=user_id)
     logger.info("About to begin sync for user {}.".format(user.username))
     profile_sync_succeeded = sync_user_profile_with_wk(user)
-    if user.profile.api_valid:
+    if profile_sync_succeeded:
         if not full_sync:
             new_review_count, new_synonym_count = sync_recent_unlocked_vocab_with_wk(user)
         else:
@@ -281,7 +281,7 @@ def sync_with_wk(user_id, full_sync=False):
 
         return profile_sync_succeeded, new_review_count, new_synonym_count
     else:
-        logger.warn(
+        logger.warning(
             "Not attempting to sync, since API key is invalid, or user has indicated they do not want to be followed ")
 
 

--- a/kw_webapp/wanikani/wanikani_api_handler.py
+++ b/kw_webapp/wanikani/wanikani_api_handler.py
@@ -29,12 +29,8 @@ def _get_error(response):
 
 def make_api_call(api_url):
     response = requests.get(api_url)
-    try:
-        if _has_no_errors(response):
-            return response.json()
-        elif _has_invalid_key_error(response):
-            raise _get_error(response)
-    except Exception:
-        logger.error("Error while attempting to make api call at {}".format(api_url), exc_info=1)
+    if response.status_code == 200:
+        return response.json()
 
-
+    if response.status_code == 401:
+        raise exceptions.InvalidWaniKaniKey("Got a 401 from Wanikani!")


### PR DESCRIPTION
Closes #356 

WK api has changed so that it no longer returns 
```
{
    "error": "user_not_found"
}
```
on invalid API keys. Instead we just check for 401. 