### PR TITLE
Bug/377 reset level bringing user to 1

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -24,3 +24,10 @@ class IsAuthenticatedOrCreating(IsAuthenticated):
     def has_permission(self, request, view):
         is_authenticated = super().has_permission(request, view)
         return is_authenticated or request.method == 'POST'
+
+
+class IsAdminOrAuthenticatedAndCreating(IsAuthenticated):
+    def has_permission(self, request, view):
+        is_authenticated = super().has_permission(request, view)
+        return (is_authenticated and request.method in ['POST', 'PUT']) or request.user.is_staff
+

--- a/api/views.py
+++ b/api/views.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse_lazy
 
 from api.filters import VocabularyFilter, ReviewFilter
-from api.permissions import IsAdminOrReadOnly, IsAuthenticatedOrCreating
+from api.permissions import IsAdminOrReadOnly, IsAuthenticatedOrCreating, IsAdminOrAuthenticatedAndCreating
 from api.serializers import ReviewSerializer, VocabularySerializer, StubbedReviewSerializer, \
     HyperlinkedVocabularySerializer, ReadingSerializer, LevelSerializer, ReadingSynonymSerializer, \
     FrequentlyAskedQuestionSerializer, AnnouncementSerializer, UserSerializer, ContactSerializer, ProfileSerializer, \
@@ -151,9 +151,9 @@ class VocabularyViewSet(RequestLoggingMixin, viewsets.ReadOnlyModelViewSet):
 class ReportViewSet(RequestLoggingMixin, viewsets.ModelViewSet):
     filter_fields = ('created_by', 'reading')
     serializer_class = ReportSerializer
+    permission_classes = (IsAdminOrAuthenticatedAndCreating,)
 
     @list_route(methods=["GET"])
-    @permission_classes((IsAdminUser,))
     def counts(self, request):
         serializer = ReportCountSerializer(Report.objects.all())
         return Response(serializer.data)
@@ -185,9 +185,7 @@ class ReportViewSet(RequestLoggingMixin, viewsets.ModelViewSet):
             return ReportListSerializer
         return super().get_serializer_class()
 
-    @permission_classes(IsAdminUser,)
     def destroy(self, request, *args, **kwargs):
-        logger.info("User " + self.request.user.username + " is deleting report " + s)
         return super().destroy(request, *args, **kwargs)
 
 

--- a/kw_webapp/tasks.py
+++ b/kw_webapp/tasks.py
@@ -586,14 +586,16 @@ def follow_user(user):
         user.profile.save()
 
 
-def reset_user(user, reset_to_level=None):
+def disable_follow_me(user):
+    user.profile.follow_me = False
+    user.profile.save()
+
+
+def reset_user(user, reset_to_level):
     reset_levels(user, reset_to_level)
     reset_reviews(user, reset_to_level)
-    #In case user provides a level, it is enough to just delete everything above.
-    #Upon not providing a level, we must clear everything away, and then rebuild,
-    #thus we must re-unlock the user's current level.
-    if not reset_to_level:
-        unlock_eligible_vocab_from_levels(user, user.profile.level)
+    disable_follow_me(user)
+    sync_user_profile_with_wk(user)
 
 
 def reset_levels(user, reset_to_level=None):
@@ -611,7 +613,7 @@ def reset_reviews(user, reset_to_level=None):
 
     #If optional level is passed, delete only reviews in which are above given level.
     if reset_to_level:
-        reviews_to_delete = reviews_to_delete.exclude(vocabulary__readings__level__lte=reset_to_level)
+        reviews_to_delete = reviews_to_delete.exclude(vocabulary__readings__level__lt=reset_to_level)
 
     reviews_to_delete.delete()
 

--- a/kw_webapp/tasks.py
+++ b/kw_webapp/tasks.py
@@ -598,22 +598,13 @@ def reset_user(user, reset_to_level):
     sync_user_profile_with_wk(user)
 
 
-def reset_levels(user, reset_to_level=None):
-    if reset_to_level:
-        user.profile.unlocked_levels.filter(level__gt=reset_to_level).delete()
-        user.profile.level = reset_to_level
-    else:
-        user.profile.unlocked_levels.clear()
-        user.profile.unlocked_levels.get_or_create(level=user.profile.level)
+def reset_levels(user, reset_to_level):
+    user.profile.unlocked_levels.filter(level__gt=reset_to_level).delete()
     user.profile.save()
 
 
-def reset_reviews(user, reset_to_level=None):
+def reset_reviews(user, reset_to_level):
     reviews_to_delete = UserSpecific.objects.filter(user=user)
-
-    #If optional level is passed, delete only reviews in which are above given level.
-    if reset_to_level:
-        reviews_to_delete = reviews_to_delete.exclude(vocabulary__readings__level__lt=reset_to_level)
-
+    reviews_to_delete = reviews_to_delete.exclude(vocabulary__readings__level__lt=reset_to_level)
     reviews_to_delete.delete()
 

--- a/kw_webapp/tests/test_profile_api.py
+++ b/kw_webapp/tests/test_profile_api.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from time import sleep
 from unittest import mock
 
+import responses
 from django.utils import timezone
 from rest_framework.renderers import JSONRenderer
 from rest_framework.reverse import reverse, reverse_lazy
@@ -14,12 +15,20 @@ from kw_webapp.constants import WkSrsLevel, WANIKANI_SRS_LEVELS
 from kw_webapp.models import Level, Report, Announcement, Vocabulary, MeaningSynonym, AnswerSynonym
 from kw_webapp.tasks import get_vocab_by_kanji, sync_with_wk
 from kw_webapp.tests.utils import create_user, create_profile, create_vocab, create_reading, create_userspecific, \
-    create_review_for_specific_time
+    create_review_for_specific_time, mock_vocab_list_response_with_single_vocabulary, mock_user_info_response
 from kw_webapp.utils import one_time_orphaned_level_clear
 
 
 class TestProfileApi(APITestCase):
+
+    def prepare_admin(self):
+        self.admin = create_user("admin")
+        create_profile(self.admin, "any_key", 5)
+        self.admin.is_staff = True
+        self.admin.save()
+
     def setUp(self):
+        self.prepare_admin()
         self.user = create_user("Tadgh")
         create_profile(self.user, "any_key", 5)
         self.vocabulary = create_vocab("radioactive bat")
@@ -303,7 +312,6 @@ class TestProfileApi(APITestCase):
         self.assertTrue('review' not in response.data['vocabulary'])
 
     def test_profile_serializer_gets_correct_srs_counts(self):
-
         review1 = create_review_for_specific_time(self.user, "guru", timezone.now()+ timedelta(hours=12))
         review1.streak = 4
         review1.save()
@@ -317,24 +325,23 @@ class TestProfileApi(APITestCase):
         self.client.force_login(user=self.user)
         response = self.client.get(reverse("api:user-me"))
 
-        pp = pprint.PrettyPrinter(indent=4)
-        pp.pprint(response.data)
-
-
+    @responses.activate
     def test_adding_a_level_to_reset_command_only_resets_levels_above_or_equal_togiven(self):
         self.client.force_login(user=self.user)
         v = create_vocab("test")
         create_reading(v, "test", "test", 3)
         create_userspecific(v, self.user)
-        self.user.profile.unlocked_levels.get_or_create(level=3)
+        mock_user_info_response(self.user.profile.api_key)
+
+        self.user.profile.unlocked_levels.get_or_create(level=2)
         response = self.client.get((reverse("api:review-current")))
         self.assertEqual(response.data['count'], 2)
-        self.assertListEqual(self.user.profile.unlocked_levels_list(), [5,3])
+        self.assertListEqual(self.user.profile.unlocked_levels_list(), [5,2])
         self.client.post(reverse("api:user-reset"), data={'level': 3})
 
         response = self.client.get((reverse("api:review-current")))
         self.assertEqual(response.data['count'], 0)
-        self.assertListEqual(self.user.profile.unlocked_levels_list(), [3])
+        self.assertListEqual(self.user.profile.unlocked_levels_list(), [2])
 
     def test_locking_a_level_successfully_clears_the_level_object(self):
         self.client.force_login(user=self.user)
@@ -406,12 +413,14 @@ class TestProfileApi(APITestCase):
         self.client.force_login(user=user)
         self.client.post(reverse("api:report-list"), data={"reading": self.reading.id, "reason": "This still makes no sense!!!"})
 
-        #Report another vocab, but only once
+        # Report another vocab, but only once
         new_vocab = create_vocab("some other vocab")
         reading = create_reading(new_vocab, "reading", "reading_char", 1)
 
         self.client.post(reverse("api:report-list"), data={"reading": reading.id, "reason": "This still makes no sense!!!"})
 
+        # Login with admin
+        self.client.force_login(self.admin)
         resp = self.client.get(reverse("api:report-counts"))
 
         assert(resp.data[0]["report_count"] > resp.data[1]["report_count"])
@@ -423,7 +432,7 @@ class TestProfileApi(APITestCase):
         assert(resp.data[1]['reading'] == reading.id)
 
         resp = self.client.get(reverse("api:report-list"))
-        assert(resp.data["count"] == 2)
+        assert(resp.data["count"] == 3)
 
     def test_ordering_on_announcements_works(self):
 
@@ -610,18 +619,20 @@ class TestProfileApi(APITestCase):
         })
         assert(response.status_code == 201)
 
+    @responses.activate
     def test_when_user_resets_account_to_a_given_level_their_current_level_is_also_set(self):
         # Given
+        mock_user_info_response(self.user.profile.api_key)
         self.client.force_login(self.user)
         assert(self.user.profile.level == 5)
 
         # When
-        response = self.client.post(reverse("api:user-reset"))
+        response = self.client.post(reverse("api:user-reset"), data={'level': 1})
         assert("Your account has been reset" in response.data['message'])
 
         # Then
         self.user.profile.refresh_from_db()
-        assert(self.user.profile.level == 5)
+        assert(self.user.profile.level == 17)
 
 
 

--- a/kw_webapp/tests/test_tasks.py
+++ b/kw_webapp/tests/test_tasks.py
@@ -370,9 +370,9 @@ class TestTasks(TestCase):
                       status=200,
                       content_type='application/json')
 
-        reset_user(self.user)
+        reset_user(self.user, 1)
 
         self.user.refresh_from_db()
-        self.assertEqual(get_users_lessons(self.user).count(), 1)
-        self.assertEqual(self.user.profile.unlocked_levels_list()[0], 5)
+        self.assertEqual(get_users_lessons(self.user).count(), 0)
+        self.assertEqual(self.user.profile.unlocked_levels_list(), [])
 

--- a/kw_webapp/tests/test_tasks.py
+++ b/kw_webapp/tests/test_tasks.py
@@ -10,11 +10,12 @@ from kw_webapp.tasks import create_new_vocabulary, past_time, all_srs, associate
     build_API_sync_string_for_user, sync_unlocked_vocab_with_wk, \
     lock_level_for_user, unlock_all_possible_levels_for_user, build_API_sync_string_for_user_for_levels, \
     user_returns_from_vacation, get_users_future_reviews, sync_all_users_to_wk, \
-    reset_user, get_users_current_reviews, reset_levels, get_users_lessons, get_vocab_by_kanji
+    reset_user, get_users_current_reviews, reset_levels, get_users_lessons, get_vocab_by_kanji, \
+    build_user_information_api_string
 from kw_webapp.tests import sample_api_responses
 from kw_webapp.tests.sample_api_responses import single_vocab_requested_information
 from kw_webapp.tests.utils import create_userspecific, create_vocab, create_user, create_profile, create_reading, \
-    create_review_for_specific_time
+    create_review_for_specific_time, mock_vocab_list_response_with_single_vocabulary, mock_user_info_response
 from kw_webapp.utils import generate_user_stats, one_time_merge_level
 
 
@@ -352,9 +353,9 @@ class TestTasks(TestCase):
         self.user.profile.unlocked_levels.get_or_create(level=4)
         self.user.refresh_from_db()
         self.assertListEqual(self.user.profile.unlocked_levels_list(), [5, 1, 2, 3, 4])
-        reset_levels(self.user)
+        reset_levels(self.user, 1)
         self.user.refresh_from_db()
-        self.assertListEqual(self.user.profile.unlocked_levels_list(), [5])
+        self.assertListEqual(self.user.profile.unlocked_levels_list(), [])
 
     @responses.activate
     def test_when_user_resets_their_account_we_remove_all_reviews_and_then_unlock_their_current_level(self):
@@ -364,15 +365,13 @@ class TestTasks(TestCase):
         new_review.save()
         self.assertEqual(get_users_current_reviews(self.user).count(), 2)
 
-        #Mock response so that the level changes on our default vocab.
-        responses.add(responses.GET, build_API_sync_string_for_user_for_levels(self.user, self.user.profile.level),
-                      json=sample_api_responses.single_vocab_response,
-                      status=200,
-                      content_type='application/json')
+        mock_vocab_list_response_with_single_vocabulary(self.user)
+        mock_user_info_response(self.user.profile.api_key)
 
         reset_user(self.user, 1)
 
         self.user.refresh_from_db()
+        self.user.profile.refresh_from_db()
         self.assertEqual(get_users_lessons(self.user).count(), 0)
-        self.assertEqual(self.user.profile.unlocked_levels_list(), [])
+        self.assertEqual(self.user.profile.level, 17)
 

--- a/kw_webapp/tests/utils.py
+++ b/kw_webapp/tests/utils.py
@@ -1,9 +1,12 @@
 from datetime import timedelta
 
+import responses
 from django.contrib.auth.models import User
 
 from kw_webapp.constants import API_KEY
 from kw_webapp.models import Vocabulary, Reading, UserSpecific, Profile
+from kw_webapp.tasks import build_user_information_api_string, build_API_sync_string_for_user_for_levels
+from kw_webapp.tests import sample_api_responses
 
 
 def create_user(username):
@@ -46,8 +49,21 @@ def create_review_for_specific_time(user, meaning, time_to_review):
     timed_review.save()
     return timed_review
 
+
 def build_test_api_string_for_merging():
     api_call = "https://www.wanikani.com/api/user/{}/vocabulary/TEST".format(API_KEY)
     return api_call
 
 
+def mock_vocab_list_response_with_single_vocabulary(user):
+    responses.add(responses.GET, build_API_sync_string_for_user_for_levels(user, user.profile.level),
+                  json=sample_api_responses.single_vocab_response,
+                  status=200,
+                  content_type='application/json')
+
+
+def mock_user_info_response(api_key):
+    responses.add(responses.GET, build_user_information_api_string(api_key),
+                  json=sample_api_responses.user_information_response,
+                  status=200,
+                  content_type='application/json')


### PR DESCRIPTION
Upon reset:
* Set level to current WK level. 
* Clear all levels greater than or equal to requested level. 
* Clear all reviews with reading levels greater than or equal to requested level. 