### PR TITLE
Add separte endpoint for review/lesson counts

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -87,6 +87,21 @@ class DetailedUpcomingReviewCountSerializer(serializers.BaseSerializer):
         return real_retval
 
 
+class ReviewCountSerializer(serializers.BaseSerializer):
+
+    def to_representation(self, user):
+        return {
+            "reviews_count": self.get_reviews_count(user),
+            "lessons_count": self.get_lessons_count(user),
+        }
+
+    def get_reviews_count(self, obj):
+        return get_users_current_reviews(obj).count()
+
+    def get_lessons_count(self, obj):
+        return get_users_lessons(obj).count()
+
+
 class ProfileSerializer(serializers.ModelSerializer):
     name = serializers.ReadOnlyField(source='user.username')
     reviews_count = serializers.SerializerMethodField()

--- a/api/views.py
+++ b/api/views.py
@@ -15,7 +15,8 @@ from api.permissions import IsAdminOrReadOnly, IsAuthenticatedOrCreating, IsAdmi
 from api.serializers import ReviewSerializer, VocabularySerializer, StubbedReviewSerializer, \
     HyperlinkedVocabularySerializer, ReadingSerializer, LevelSerializer, ReadingSynonymSerializer, \
     FrequentlyAskedQuestionSerializer, AnnouncementSerializer, UserSerializer, ContactSerializer, ProfileSerializer, \
-    ReportSerializer, ReportCountSerializer, ReportListSerializer, MeaningSynonymSerializer, RegistrationSerializer
+    ReportSerializer, ReportCountSerializer, ReportListSerializer, MeaningSynonymSerializer, RegistrationSerializer, \
+    ReviewCountSerializer
 from kw_webapp import constants
 from kw_webapp.forms import UserContactCustomForm
 from kw_webapp.models import Vocabulary, UserSpecific, Reading, Level, AnswerSynonym, FrequentlyAskedQuestion, \
@@ -291,6 +292,12 @@ class ReviewViewSet(RequestLoggingMixin, ListRetrieveUpdateViewSet):
     @detail_route(methods=['POST'])
     def unhide(self, request, pk=None):
         return self._set_hidden(request, False, pk)
+
+    @list_route(methods=['GET'])
+    def counts(self, request):
+        user = request.user
+        serializer = ReviewCountSerializer(user)
+        return Response(serializer.data)
 
     def _set_hidden(self, request, should_hide, pk=None):
         review = get_object_or_404(UserSpecific, pk=pk)

--- a/kw_webapp/tests/test_profile_api.py
+++ b/kw_webapp/tests/test_profile_api.py
@@ -759,3 +759,14 @@ class TestProfileApi(APITestCase):
         response = self.client.patch(reverse("api:profile-detail", args=(data['id'],)), data=patch)
         self.assertEqual(response.status_code, 400)
 
+    def test_review_counts_endpoints(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("api:review-counts"))
+        data = response.data
+        self.assertIsNotNone(data['reviews_count'])
+        self.assertIsNotNone(data['lessons_count'])
+
+
+
+


### PR DESCRIPTION
Completes first part of #415 , by adding a separate review count endpoint at `/api/v1/review/counts/`