### PR TITLE
Chore/408 return json by default on all errors

### DIFF
--- a/KW/settings.py
+++ b/KW/settings.py
@@ -188,6 +188,10 @@ REST_FRAMEWORK = {
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
         'rest_framework.authentication.SessionAuthentication'
     ],
+    'DEFAULT_RENDERER_CLASSES': [
+        # Simple overridden class which will dump empty JSON into the response if we find that the content is empty.
+        'kw_webapp.renderers.FallbackJSONRenderer'
+    ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)

--- a/api/views.py
+++ b/api/views.py
@@ -440,6 +440,7 @@ class ContactViewSet(RequestLoggingMixin, generics.CreateAPIView, viewsets.Gener
         if not form.is_valid():
             return Response(form.errors, status=status.HTTP_400_BAD_REQUEST)
         form.save()
-        return Response({"detail": "Successfully sent contact email"}, status=status.HTTP_202_ACCEPTED)
+        return Response(status=status.HTTP_202_ACCEPTED)
+        # return Response({"detail": "Successfully sent contact email"}, status=status.HTTP_202_ACCEPTED)
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -5,6 +5,7 @@ from rest_framework import mixins
 from rest_framework import status
 from rest_framework import viewsets
 from rest_framework.decorators import list_route, detail_route, permission_classes
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.response import Response
@@ -268,7 +269,7 @@ class ReviewViewSet(RequestLoggingMixin, ListRetrieveUpdateViewSet):
     def correct(self, request, pk=None):
         review = get_object_or_404(UserSpecific, pk=pk)
         if not review.can_be_managed_by(request.user) or not review.needs_review:
-            return HttpResponseForbidden("You can't modify that object at this time!")
+            raise PermissionDenied("You can't review a review that doesn't need to be reviewed! ٩(ఠ益ఠ)۶")
 
         was_correct_on_first_try = self._correct_on_first_try(request)
         review = review.answered_correctly(was_correct_on_first_try)
@@ -279,7 +280,7 @@ class ReviewViewSet(RequestLoggingMixin, ListRetrieveUpdateViewSet):
     def incorrect(self, request, pk=None):
         review = get_object_or_404(UserSpecific, pk=pk)
         if not review.can_be_managed_by(request.user) or not review.needs_review:
-            return HttpResponseForbidden("You can't modify that object at this time!")
+            raise PermissionDenied("You can't review a review that doesn't need to be reviewed! ٩(ఠ益ఠ)۶")
         review = review.answered_incorrectly()
         serializer = self.get_serializer(review, many=False)
         return Response(serializer.data)

--- a/api/views.py
+++ b/api/views.py
@@ -440,7 +440,6 @@ class ContactViewSet(RequestLoggingMixin, generics.CreateAPIView, viewsets.Gener
         if not form.is_valid():
             return Response(form.errors, status=status.HTTP_400_BAD_REQUEST)
         form.save()
-
-        return Response(status=status.HTTP_202_ACCEPTED)
+        return Response({"detail": "Successfully sent contact email"}, status=status.HTTP_202_ACCEPTED)
 
 

--- a/kw_webapp/renderers.py
+++ b/kw_webapp/renderers.py
@@ -1,0 +1,13 @@
+
+from rest_framework import renderers
+
+
+class FallbackJSONRenderer(renderers.JSONRenderer):
+    '''
+    In order for all endpoints to return JSON, we use this renderer to automatically fill the an empty JSON response in
+    cases where it would normally be null.
+    '''
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        if data is None:
+            data = {"detail": "none"}
+        return super().render(data, accepted_media_type, renderer_context)

--- a/kw_webapp/tasks.py
+++ b/kw_webapp/tasks.py
@@ -283,12 +283,17 @@ def create_new_vocabulary(vocabulary_json):
     '''
     meaning = vocabulary_json["meaning"]
     vocab = Vocabulary.objects.create(meaning=meaning)
-    vocab = associate_readings_to_vocab(vocab, vocabulary_json)
+    vocab = update_local_vocabulary_information(vocab, vocabulary_json)
     return vocab
 
 
-def associate_readings_to_vocab(vocab, vocabulary_json):
+def update_local_vocabulary_information(vocab, vocabulary_json):
+
     kana_list = [reading.strip() for reading in vocabulary_json["kana"].split(",")]
+    # Update the local meaning based on WK meaning
+    meaning = vocabulary_json['meaning']
+    vocab.meaning = meaning
+
     character = vocabulary_json["character"]
     level = vocabulary_json["level"]
     for reading in kana_list:
@@ -299,6 +304,7 @@ def associate_readings_to_vocab(vocab, vocabulary_json):
             logger.info("""Created new reading: {}, level {}
                                      associated to vocab {}""".format(new_reading.kana, new_reading.level,
                                                                       new_reading.vocabulary.meaning))
+    vocab.save()
     return vocab
 
 
@@ -443,7 +449,7 @@ def process_single_item_from_wanikani(vocabulary, user):
 
 def import_vocabulary_from_json(vocabulary):
     vocab, is_new = get_or_create_vocab_by_json(vocabulary)
-    vocab = associate_readings_to_vocab(vocab, vocabulary)
+    vocab = update_local_vocabulary_information(vocab, vocabulary)
     return vocab, is_new
 
 

--- a/kw_webapp/tests/sample_api_responses.py
+++ b/kw_webapp/tests/sample_api_responses.py
@@ -162,11 +162,27 @@ added_meaning_to_conglomerate_vocab_sample_response = {
     }]
 }
 
-user_information_response = {
+user_information_response_with_higher_level = {
     "user_information": {
         "username": "Tadgh11",
         "gravatar": "a9453be85d2e722fd7e3b3424a38be30",
         "level": 17,
+        "title": "Turtles",
+        "about": "",
+        "website": "http://www.kaniwani.com",
+        "twitter": "@Tadgh11",
+        "topics_count": 1,
+        "posts_count": 81,
+        "creation_date": 1373371374,
+        "vacation_date": None
+    }
+}
+
+user_information_response = {
+    "user_information": {
+        "username": "Tadgh11",
+        "gravatar": "a9453be85d2e722fd7e3b3424a38be30",
+        "level": 5,
         "title": "Turtles",
         "about": "",
         "website": "http://www.kaniwani.com",
@@ -209,6 +225,52 @@ single_vocab_response_with_4_meaning_synonyms = {
         "character": "猫",
         "kana": "ねこ",
         "meaning": "radioactive bat",
+        "level": 16,
+        "user_specific": {
+            "srs": "apprentice",
+            "srs_numeric": 3,
+            "unlocked_date": 1448398437,
+            "available_date": 1448586000,
+            "burned": False,
+            "burned_date": 0,
+            "meaning_correct": 0,
+            "meaning_incorrect": 0,
+            "meaning_max_streak": 0,
+            "meaning_current_streak": 0,
+            "reading_correct": 0,
+            "reading_incorrect": 0,
+            "reading_max_streak": 0,
+            "reading_current_streak": 0,
+            "meaning_note": None,
+            "user_synonyms": [
+                "synonym_1",
+                "synonym_2",
+                "synonym_3",
+                "synonym_4",
+            ],
+            "reading_note": None
+        }
+    }]
+}
+
+single_vocab_response_with_changed_meaning = {
+    "user_information": {
+        "username": "Tadgh11",
+        "gravatar": "a9453be85d2e722fd7e3b3424a38be30",
+        "level": 16,
+        "title": "Turtles",
+        "about": "",
+        "website": "http://www.kaniwani.com",
+        "twitter": "@Tadgh11",
+        "topics_count": 1,
+        "posts_count": 81,
+        "creation_date": 1373371374,
+        "vacation_date": None
+    },
+    "requested_information": [{
+        "character": "猫",
+        "kana": "ねこ",
+        "meaning": "radioactive bat, added meaning, new meaning.",
         "level": 16,
         "user_specific": {
             "srs": "apprentice",

--- a/kw_webapp/tests/test_profile_api.py
+++ b/kw_webapp/tests/test_profile_api.py
@@ -759,3 +759,5 @@ class TestProfileApi(APITestCase):
         response = self.client.patch(reverse("api:profile-detail", args=(data['id'],)), data=patch)
         self.assertEqual(response.status_code, 400)
 
+    def test_error_codes_always_return_some_kind_of_json(self):
+        pass

--- a/kw_webapp/tests/test_profile_api.py
+++ b/kw_webapp/tests/test_profile_api.py
@@ -777,5 +777,3 @@ class TestProfileApi(APITestCase):
 
         self.vocabulary.refresh_from_db()
         self.assertEqual(self.vocabulary.meaning, sample_api_responses.single_vocab_response_with_changed_meaning['requested_information'][0]['meaning'])
-
-

--- a/kw_webapp/tests/test_profile_api.py
+++ b/kw_webapp/tests/test_profile_api.py
@@ -14,9 +14,11 @@ from kw_webapp import constants
 from kw_webapp.constants import WkSrsLevel, WANIKANI_SRS_LEVELS
 from kw_webapp.models import Level, Report, Announcement, Vocabulary, MeaningSynonym, AnswerSynonym
 from kw_webapp.tasks import get_vocab_by_kanji, sync_with_wk, sync_recent_unlocked_vocab_with_wk
+from kw_webapp.tests import sample_api_responses
 from kw_webapp.tests.utils import create_user, create_profile, create_vocab, create_reading, create_userspecific, \
     create_review_for_specific_time, mock_vocab_list_response_with_single_vocabulary, mock_user_info_response, \
-    mock_invalid_api_user_info_response, mock_vocab_list_response_with_single_vocabulary_with_four_synonyms
+    mock_invalid_api_user_info_response, mock_vocab_list_response_with_single_vocabulary_with_four_synonyms, \
+    mock_vocab_list_response_with_single_vocabulary_with_changed_meaning, mock_user_info_response_with_higher_level
 from kw_webapp.utils import one_time_orphaned_level_clear
 
 
@@ -626,7 +628,7 @@ class TestProfileApi(APITestCase):
     @responses.activate
     def test_when_user_resets_account_to_a_given_level_their_current_level_is_also_set(self):
         # Given
-        mock_user_info_response(self.user.profile.api_key)
+        mock_user_info_response_with_higher_level(self.user.profile.api_key)
         self.client.force_login(self.user)
         assert(self.user.profile.level == 5)
 
@@ -761,3 +763,19 @@ class TestProfileApi(APITestCase):
 
     def test_error_codes_always_return_some_kind_of_json(self):
         pass
+
+    @responses.activate
+    def test_vocabulary_meaning_changes_reflect_locally(self):
+        self.client.force_login(self.user)
+
+        self.assertEqual(self.vocabulary.meaning, "radioactive bat")
+
+        mock_user_info_response(self.user.profile.api_key)
+        mock_vocab_list_response_with_single_vocabulary_with_changed_meaning(self.user)
+
+        sync_with_wk(self.user.id)
+
+        self.vocabulary.refresh_from_db()
+        self.assertEqual(self.vocabulary.meaning, sample_api_responses.single_vocab_response_with_changed_meaning['requested_information'][0]['meaning'])
+
+

--- a/kw_webapp/tests/test_tasks.py
+++ b/kw_webapp/tests/test_tasks.py
@@ -391,5 +391,5 @@ class TestTasks(TestCase):
         self.user.refresh_from_db()
         self.user.profile.refresh_from_db()
         self.assertEqual(get_users_lessons(self.user).count(), 0)
-        self.assertEqual(self.user.profile.level, 17)
+        self.assertEqual(self.user.profile.level, 5)
 

--- a/kw_webapp/tests/test_views.py
+++ b/kw_webapp/tests/test_views.py
@@ -75,3 +75,14 @@ class TestViews(TestCase):
         response = self.client.post(reverse("api:review-incorrect", args=(self.review.id,)))
         self.assertEqual(response.status_code, 403)
         self.assertIsNotNone(response.data['detail'])
+
+    def test_sending_contact_email_returns_json_response(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(reverse("api:contact-list"), data={
+            "name": "test",
+            "email": "test@test.com",
+            "body": "test",
+        })
+        json = response.data
+        self.assertIsNotNone(json)

--- a/kw_webapp/tests/test_views.py
+++ b/kw_webapp/tests/test_views.py
@@ -84,5 +84,5 @@ class TestViews(TestCase):
             "email": "test@test.com",
             "body": "test",
         })
-        json = response.data
+        json = response.content
         self.assertIsNotNone(json)

--- a/kw_webapp/tests/test_views.py
+++ b/kw_webapp/tests/test_views.py
@@ -69,4 +69,9 @@ class TestViews(TestCase):
         self.review.save()
 
         response = self.client.post(reverse("api:review-correct", args=(self.review.id,)), data={'wrong_before': 'false'})
-        self.assertTrue(isinstance(response, HttpResponseForbidden))
+        self.assertEqual(response.status_code, 403)
+        self.assertIsNotNone(response.data['detail'])
+
+        response = self.client.post(reverse("api:review-incorrect", args=(self.review.id,)))
+        self.assertEqual(response.status_code, 403)
+        self.assertIsNotNone(response.data['detail'])

--- a/kw_webapp/tests/test_views.py
+++ b/kw_webapp/tests/test_views.py
@@ -33,7 +33,7 @@ class TestViews(TestCase):
     def test_sync_now_endpoint_returns_correct_json(self):
         responses.add(responses.GET,
                       "https://www.wanikani.com/api/user/{}/user-information".format(self.user.profile.api_key),
-                      json=sample_api_responses.user_information_response,
+                      json=sample_api_responses.user_information_response_with_higher_level,
                       status=200,
                       content_type="application/json")
 

--- a/kw_webapp/tests/utils.py
+++ b/kw_webapp/tests/utils.py
@@ -62,6 +62,13 @@ def mock_vocab_list_response_with_single_vocabulary(user):
                   content_type='application/json')
 
 
+def mock_user_info_response_with_higher_level(api_key):
+    responses.add(responses.GET, build_user_information_api_string(api_key),
+                  json=sample_api_responses.user_information_response_with_higher_level,
+                  status=200,
+                  content_type='application/json')
+
+
 def mock_user_info_response(api_key):
     responses.add(responses.GET, build_user_information_api_string(api_key),
                   json=sample_api_responses.user_information_response,
@@ -79,5 +86,12 @@ def mock_invalid_api_user_info_response(api_key):
 def mock_vocab_list_response_with_single_vocabulary_with_four_synonyms(user):
     responses.add(responses.GET, build_API_sync_string_for_user_for_levels(user, [user.profile.level, ]),
                   json=sample_api_responses.single_vocab_response_with_4_meaning_synonyms,
+                  status=200,
+                  content_type='application/json')
+
+
+def mock_vocab_list_response_with_single_vocabulary_with_changed_meaning(user):
+    responses.add(responses.GET, build_API_sync_string_for_user_for_levels(user, [user.profile.level, ]),
+                  json=sample_api_responses.single_vocab_response_with_changed_meaning,
                   status=200,
                   content_type='application/json')


### PR DESCRIPTION
Closes #408 and #417 . 
* Add default renderer to add some JSON into responsebody whenever it is missing ( and possible to add) 
* re-add check for meaning during sync time. 
* add related tests.