### PR TITLE
Adds functionality to reset any reviews individually

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -216,6 +216,9 @@ class ReviewViewSet(RequestLoggingMixin, ListRetrieveUpdateViewSet):
 
     unhide:
     include this item in the SRS algorithm and review queue.
+
+    reset:
+    Reset all SRS information relating to this review.
     """
     serializer_class = ReviewSerializer
     filter_class = ReviewFilter
@@ -299,6 +302,12 @@ class ReviewViewSet(RequestLoggingMixin, ListRetrieveUpdateViewSet):
         user = request.user
         serializer = ReviewCountSerializer(user)
         return Response(serializer.data)
+
+    @detail_route(methods=['POST'])
+    def reset(self, request, pk=None):
+        review = get_object_or_404(UserSpecific, pk=pk)
+        review.reset()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     def _set_hidden(self, request, should_hide, pk=None):
         review = get_object_or_404(UserSpecific, pk=pk)

--- a/kw_webapp/models.py
+++ b/kw_webapp/models.py
@@ -333,6 +333,17 @@ class UserSpecific(models.Model):
             self._round_review_time_up()
             self._round_last_studied_up()
 
+    def reset(self):
+        # During a reset, we bring them down to the lowest review level, _not_ lesson level.
+        self.streak = 1
+        self.last_studied = None
+        self.next_review_date = timezone.now()
+        self.correct = 1
+        self.incorrect = 0
+        self.burned = False
+        self.needs_review = True
+        self.save()
+
     def _round_last_studied_up(self):
         original_date = self.last_studied
         round_to = constants.REVIEW_ROUNDING_TIME.total_seconds()


### PR DESCRIPTION
Closes #420 

* Adds endpoint `/review/{id}/reset` which will destroy all known SRS data for this review. 
* Review then gets set to `streak=1` so as to avoid being a lesson.