### PR TITLE
Fix being unable to login via email

### DIFF
--- a/KW/settings.py
+++ b/KW/settings.py
@@ -229,6 +229,7 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
 ]
 
+
 DJOSER = {
     "SERIALIZERS": {
         "user_create": "api.serializers.RegistrationSerializer",

--- a/kw_webapp/backends.py
+++ b/kw_webapp/backends.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 
 
 class EmailOrUsernameAuthenticationBackend:
-    def authenticate(self, username=None, password=None):
+    def authenticate(self, request, username=None, password=None):
         if "@" in username:
             kwargs = {"email": username}
         else:

--- a/kw_webapp/tests/utils.py
+++ b/kw_webapp/tests/utils.py
@@ -15,7 +15,7 @@ from kw_webapp.tests import sample_api_responses, sample_api_responses_v2
 
 
 def create_user(username):
-    u = User.objects.create(username=username)
+    u = User.objects.create(username=username, email=username + "@gmail.com")
     u.set_password(username)
     u.save()
     return u

--- a/kw_webapp/tests/views/test_user.py
+++ b/kw_webapp/tests/views/test_user.py
@@ -4,7 +4,7 @@ import responses
 from django.utils import timezone
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
-
+import KW.settings as settings
 from kw_webapp.models import Profile
 from kw_webapp.tasks import build_API_sync_string_for_user_for_levels
 from kw_webapp.tests import sample_api_responses
@@ -146,3 +146,19 @@ class TestUser(APITestCase):
 
         user_profile = Profile.objects.get(user__username=fake_username)
         assert len(user_profile.unlocked_levels_list()) == 2
+
+    def test_login_works_with_email_or_username(self):
+        response = self.client.post(
+            settings.LOGIN_URL,
+            data={
+                "username": self.user.username,
+                "password": self.user.username,
+            },
+        )
+        assert response.status_code == 200
+
+        response = self.client.post(
+            settings.LOGIN_URL,
+            data={"username": self.user.email, "password": self.user.username},
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
While upgrading django, there was a change made to the call parameters of `authenticate` which was not accounted for. 

* Test added
* Parameter added so that the inspect call passes. 
* Note that the parameter is unused, but must be there. 