### PR TITLE
add prefetching and preselecting to heavily hit endpoints

### DIFF
--- a/KW/settings.py
+++ b/KW/settings.py
@@ -27,6 +27,7 @@ log_root = root.path("logs")
 env = environ.Env(DEBUG=(bool, False))
 environ.Env.read_env(root.path("KW").file(".env"))
 
+
 LOGLEVEL = env("LOGLEVEL", default="INFO").upper()
 
 # This allows the /docs/ endpoints to correctly build urls.
@@ -123,6 +124,7 @@ INSTALLED_APPS = (
     "django_filters",
     "corsheaders",
     "djoser",
+    "silk",
 )
 
 MIDDLEWARE = [
@@ -136,8 +138,10 @@ MIDDLEWARE = [
     "django.middleware.gzip.GZipMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
     "kw_webapp.middleware.SetLastVisitMiddleware",
+    "silk.middleware.SilkyMiddleware",  # lock this down to only be used in debug mode at some point.
 ]
 
+DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda _request: DEBUG}
 if DEBUG:
     MIDDLEWARE += ["KW.LoggingMiddleware.ExceptionLoggingMiddleware"]
 

--- a/KW/urls.py
+++ b/KW/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import path
 from django.views.generic import RedirectView
 from rest_framework.documentation import include_docs_urls
 
@@ -17,4 +18,5 @@ urlpatterns = (
 if settings.DEBUG:
     import debug_toolbar
 
+    urlpatterns += (url(r"^silk/", include("silk.urls", namespace="silk")),)
     urlpatterns += (url(r"^__debug__/", include(debug_toolbar.urls)),)

--- a/api/validators.py
+++ b/api/validators.py
@@ -22,7 +22,7 @@ class WanikaniApiKeyValidatorV1(object):
                 logger.debug(f"We have valiated API V1 Key {value}")
                 return value
 
-        logger.debug(f"We failed to validate API V2 Key {value}")
+        logger.debug(f"We failed to validate API V1 Key {value}")
         raise serializers.ValidationError(self.failure_message)
 
     def build_v1_user_information_api_string(self, api_key):

--- a/api/views.py
+++ b/api/views.py
@@ -297,7 +297,16 @@ class ReviewViewSet(ListRetrieveUpdateViewSet):
 
     @action(detail=False)
     def lesson(self, request):
-        lessons = get_users_lessons(request.user)
+        lessons = (
+            get_users_lessons(request.user)
+            .select_related("vocabulary")
+            .prefetch_related(
+                "meaning_synonyms",
+                "reading_synonyms",
+                "vocabulary__readings",
+                "vocabulary__readings__parts_of_speech",
+            )
+        )
         page = self.paginate_queryset(lessons)
         if page is not None:
             serializer = StubbedReviewSerializer(page, many=True)
@@ -309,7 +318,16 @@ class ReviewViewSet(ListRetrieveUpdateViewSet):
     @action(detail=False)
     def current(self, request):
         logger.info(f"Fetching current reviews for: {request.user.username}")
-        reviews = get_users_current_reviews(request.user)
+        reviews = (
+            get_users_current_reviews(request.user)
+            .select_related("vocabulary")
+            .prefetch_related(
+                "meaning_synonyms",
+                "reading_synonyms",
+                "vocabulary__readings",
+                "vocabulary__readings__parts_of_speech",
+            )
+        )
         logger.debug(
             f"Fetched current reviews for: {request.user.username}. Paginating.."
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,6 @@ vine==1.1.4
 
 wanikani_api==0.2.0
 sentry-sdk==0.9.1
+
+django-silk==3.0.4
+


### PR DESCRIPTION
This should be a massive improvement for the issue reported in #461, and should clean up the first bullet point of #468 

This also adds Silk, a django profiling tool. I am leaving it enabled here to gather some rudimentary data. Very likely I will subsequently disable it (depending on its performance cost) 

*OLD*
![](https://i.gyazo.com/c63169cd71e485bf30446c6438f7fd2b.png)

*NEW*
![](https://i.gyazo.com/e5f9cd4ae2dc01e0d5acd3882070e049.png)