### PR TITLE
Add user meaning synonyms to Vocab search

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ To populate the database, you'll need to sync from Wanikani using a real API (v2
 # ./manage.py shell
 >>> from api.sync.SyncerFactory import Syncer
 >>> from kw_webapp.models import Profile
->>> from django.contrib.auth import User
->>> my_user = User(username="my_username", password="securepassword123").save()
->>> my_profile = Profile(api_key_v2="YOUR_API_KEY_HERE", user=my_user).save()
+>>> from django.contrib.auth.models import User
+>>> my_user = User(username="my_username")
+>>> my_user.set_password("securepassword123")
+>>> my_user.save()
+>>> my_profile = Profile(api_key_v2="YOUR_API_KEY_HERE", user=my_user)
+>>> my_profile.save()
 >>> syncer = Syncer.factory(my_profile)
 >>> syncer.sync_top_level_vocabulary()
 # A lot of stuff is going to happen here and you may see some errors. Don't panic unless things explode :boom:

--- a/api/filters.py
+++ b/api/filters.py
@@ -42,6 +42,11 @@ def filter_meaning_contains_for_review(queryset, name, value):
         )
 
 
+def filter_user_id_for_vocab(queryset, name, value):
+    if value:
+        return queryset.filter(Q(userspecific__user_id=value))
+
+
 def filter_vocabulary_parts_of_speech(queryset, name, value):
     if value:
         return queryset.filter(readings__parts_of_speech__part=value)
@@ -81,6 +86,7 @@ class VocabularyFilter(filters.FilterSet):
     part_of_speech = filters.CharFilter(
         method=filter_vocabulary_parts_of_speech
     )
+    user_id = filters.NumberFilter(method=filter_user_id_for_vocab)
 
     class Meta:
         model = Vocabulary

--- a/api/filters.py
+++ b/api/filters.py
@@ -2,7 +2,6 @@ import re
 
 from django.db.models import Q
 from django_filters import rest_framework as filters
-from environ import environ
 
 from kw_webapp.models import Vocabulary, UserSpecific
 
@@ -30,7 +29,10 @@ def filter_level_for_review(queryset, name, value):
 
 def filter_meaning_contains(queryset, name, value):
     if value:
-        return queryset.filter(meaning__iregex=whole_word_regex(value))
+        return queryset.filter(
+            Q(meaning__iregex=whole_word_regex(value))
+            | Q(userspecific__meaning_synonyms__text__iregex=whole_word_regex(value))
+        ).distinct()
 
 
 def filter_meaning_contains_for_review(queryset, name, value):

--- a/api/filters.py
+++ b/api/filters.py
@@ -35,16 +35,22 @@ def filter_meaning_contains(queryset, name, value):
         ).distinct()
 
 
+# Filter awkwardly shoehorned in with the FilterSet filters,
+# but used for direct filtering from the ViewSet
+def filter_user_meaning_contains(queryset, meaning_contains, user_id):
+    if meaning_contains and user_id:
+        return queryset.filter(
+            Q(meaning__iregex=whole_word_regex(meaning_contains))
+            | (Q(userspecific__meaning_synonyms__text__iregex=whole_word_regex(meaning_contains)) &
+               Q(userspecific__user_id=user_id))
+        )
+
+
 def filter_meaning_contains_for_review(queryset, name, value):
     if value:
         return queryset.filter(
             vocabulary__meaning__iregex=whole_word_regex(value)
         )
-
-
-def filter_user_id_for_vocab(queryset, name, value):
-    if value:
-        return queryset.filter(Q(userspecific__user_id=value))
 
 
 def filter_vocabulary_parts_of_speech(queryset, name, value):
@@ -86,7 +92,6 @@ class VocabularyFilter(filters.FilterSet):
     part_of_speech = filters.CharFilter(
         method=filter_vocabulary_parts_of_speech
     )
-    user_id = filters.NumberFilter(method=filter_user_id_for_vocab)
 
     class Meta:
         model = Vocabulary

--- a/api/filters.py
+++ b/api/filters.py
@@ -40,7 +40,7 @@ def filter_user_meaning_contains(queryset, meaning_contains, user_id):
             Q(meaning__iregex=whole_word_regex(meaning_contains))
             | (Q(userspecific__meaning_synonyms__text__iregex=whole_word_regex(meaning_contains)) &
                Q(userspecific__user_id=user_id))
-        )
+        ).distinct()
 
 
 def filter_meaning_contains_for_review(queryset, name, value):

--- a/api/filters.py
+++ b/api/filters.py
@@ -32,7 +32,7 @@ def filter_meaning_contains(queryset, name, value):
         return queryset.filter(meaning__iregex=whole_word_regex(value))
 
 
-# Filter awkwardly shoehorned in with the FilterSet filters,
+# This filter awkwardly shoehorned in with the FilterSet filters,
 # but used for direct filtering from the ViewSet
 def filter_user_meaning_contains(queryset, meaning_contains, user_id):
     if meaning_contains and user_id:
@@ -84,7 +84,6 @@ def filter_reading_contains_for_review(queryset, name, value):
 
 class VocabularyFilter(filters.FilterSet):
     level = filters.NumberFilter(method=filter_level_for_vocab)
-    meaning_contains = filters.CharFilter(method=filter_meaning_contains)
     reading_contains = filters.CharFilter(method=filter_reading_contains)
     part_of_speech = filters.CharFilter(
         method=filter_vocabulary_parts_of_speech

--- a/api/filters.py
+++ b/api/filters.py
@@ -29,10 +29,7 @@ def filter_level_for_review(queryset, name, value):
 
 def filter_meaning_contains(queryset, name, value):
     if value:
-        return queryset.filter(
-            Q(meaning__iregex=whole_word_regex(value))
-            | Q(userspecific__meaning_synonyms__text__iregex=whole_word_regex(value))
-        ).distinct()
+        return queryset.filter(meaning__iregex=whole_word_regex(value))
 
 
 # Filter awkwardly shoehorned in with the FilterSet filters,

--- a/api/validators.py
+++ b/api/validators.py
@@ -17,7 +17,7 @@ class WanikaniApiKeyValidatorV2(object):
         client = WkV2Client(value)
         try:
             client.user_information()
-            logger.debug(f"We have valiated API V2 Key {value}")
+            logger.debug(f"We have validated API V2 Key {value}")
             return value
         except InvalidWanikaniApiKeyException:
             logger.debug(f"We failed to validate API V2 Key {value}")

--- a/api/views.py
+++ b/api/views.py
@@ -206,9 +206,10 @@ class VocabularyViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         meaning_contains = self.request.query_params.get("meaning_contains")
-        user_id = self.request.query_params.get("user_id")
-        if meaning_contains and user_id:
-            # short-circuit filtering with the typical filterset
+        # meaning_contains short-circuits filtering with the typical filterset
+        # we need user info from request
+        if meaning_contains:
+            user_id = self.request.user.id
             self.filterset_class = None
             return filter_user_meaning_contains(Vocabulary.objects.all(), meaning_contains, user_id)
         return Vocabulary.objects.all()

--- a/kw_webapp/tests/utils.py
+++ b/kw_webapp/tests/utils.py
@@ -4,8 +4,13 @@ from datetime import timedelta
 import responses
 from django.contrib.auth.models import User
 
-from kw_webapp.constants import API_KEY
-from kw_webapp.models import Vocabulary, Reading, UserSpecific, Profile
+from kw_webapp.models import (
+    Vocabulary,
+    Reading,
+    UserSpecific,
+    Profile,
+    MeaningSynonym,
+)
 
 from requests.exceptions import ConnectionError
 from kw_webapp.tests import sample_api_responses_v2
@@ -53,6 +58,11 @@ def create_vocab(meaning):
     v = Vocabulary.objects.create(meaning=meaning)
     return v
 
+def create_vocab_with_meaning_synonym(meaning, synonym, user):
+    v = Vocabulary.objects.create(meaning=meaning)
+    review = UserSpecific.objects.create(vocabulary=v, user=user)
+    MeaningSynonym.objects.create(review=review, text=synonym)
+    return v
 
 def create_reading(vocab, reading, character, level):
     r = Reading.objects.create(


### PR DESCRIPTION
Small change to search associated user synonyms from the vocabulary search, as well as the original WK meanings of the vocab (current behavior). From the KW user's perspective, all the meanings (original and synonyms) look the same from the vocabulary listing page and in reviews, so it's confusing not to be able to search based on some of them.

This change replaces the more typical FilterSet filter on "meaning_contains" with a custom filter, so that it can make use of the user ID from the request, as well. This ensures the synonyms for the filter are only those added by the user.