### PR TITLE
Fix synonym query

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ To populate the database, you'll need to sync from Wanikani using a real API (v2
 # ./manage.py shell
 >>> from api.sync.SyncerFactory import Syncer
 >>> from kw_webapp.models import Profile
->>> from django.contrib.auth import User
->>> my_user = User(username="my_username", password="securepassword123").save()
->>> my_profile = Profile(api_key_v2="YOUR_API_KEY_HERE", user=my_user).save()
+>>> from django.contrib.auth.models import User
+>>> my_user = User(username="my_username")
+>>> my_user.set_password("securepassword123")
+>>> my_user.save()
+>>> my_profile = Profile(api_key_v2="YOUR_API_KEY_HERE", user=my_user)
+>>> my_profile.save()
 >>> syncer = Syncer.factory(my_profile)
 >>> syncer.sync_top_level_vocabulary()
 # A lot of stuff is going to happen here and you may see some errors. Don't panic unless things explode :boom:

--- a/api/filters.py
+++ b/api/filters.py
@@ -36,11 +36,12 @@ def filter_meaning_contains(queryset, name, value):
 # but used for direct filtering from the ViewSet
 def filter_user_meaning_contains(queryset, meaning_contains, user_id):
     if meaning_contains and user_id:
-        return queryset.filter(
-            Q(meaning__iregex=whole_word_regex(meaning_contains))
-            | (Q(userspecific__meaning_synonyms__text__iregex=whole_word_regex(meaning_contains)) &
-               Q(userspecific__user_id=user_id))
-        ).distinct()
+        query_statement = f"""SELECT DISTINCT * from kw_webapp_vocabulary v
+        LEFT JOIN kw_webapp_userspecific u ON v.id = u.vocabulary_id AND u.user_id = {user_id}
+        LEFT JOIN kw_webapp_meaningsynonym s ON u.id = s.review_id
+        WHERE v.meaning::text ~* '{whole_word_regex(meaning_contains)}'
+        OR s.text::text ~* '{whole_word_regex(meaning_contains)}'"""
+        return queryset.raw(query_statement)
 
 
 def filter_meaning_contains_for_review(queryset, name, value):

--- a/api/views.py
+++ b/api/views.py
@@ -211,7 +211,7 @@ class VocabularyViewSet(viewsets.ReadOnlyModelViewSet):
         if meaning_contains:
             user_id = self.request.user.id
             self.filterset_class = None
-            return filter_user_meaning_contains(Vocabulary.objects.all(), meaning_contains, user_id)
+            return filter_user_meaning_contains(meaning_contains, user_id)
         return Vocabulary.objects.all()
 
     def get_serializer_class(self):


### PR DESCRIPTION
## Overview
This change fixes the poor query performance of the user synonym meaning query added in #482, splitting out the synonyms query to use the UserSpecific manager instead of an expensive two-step join from Vocabulary -> UserSpecific -> MeaningSynonyms. 

## Testing
The previous PR wasn't tested on a large db, which led to the late discovery of the problem. I tested this change locally after adding 650,000 UserSpecific entries (for various users and properly linked to Vocabulary entries) to reproduce the delays that the previous implementation had. In this testing environment I saw a ~200x speedup for this query over the current implementation. If possible, it would be good to validate the performance on a prod db mirror to ensure it's still fast enough to meet desired response times.