### PR TITLE
Level 0 reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ To populate the database, you'll need to sync from Wanikani using a real API (v2
 # ./manage.py shell
 >>> from api.sync.SyncerFactory import Syncer
 >>> from kw_webapp.models import Profile
->>> from django.contrib.auth import User
->>> my_user = User(username="my_username", password="securepassword123").save()
->>> my_profile = Profile(api_key_v2="YOUR_API_KEY_HERE", user=my_user).save()
+>>> from django.contrib.auth.models import User
+>>> my_user = User(username="my_username")
+>>> my_user.set_password("securepassword123")
+>>> my_user.save()
+>>> my_profile = Profile(api_key_v2="YOUR_API_KEY_HERE", user=my_user)
+>>> my_profile.save()
 >>> syncer = Syncer.factory(my_profile)
 >>> syncer.sync_top_level_vocabulary()
 # A lot of stuff is going to happen here and you may see some errors. Don't panic unless things explode :boom:

--- a/kw_webapp/tasks.py
+++ b/kw_webapp/tasks.py
@@ -335,7 +335,7 @@ def reset_levels(user, reset_to_level):
     logger.info(
         f"{user.username} is having their levels cleared down to {reset_to_level}"
     )
-    user.profile.unlocked_levels.filter(level__gte=reset_to_level).delete()
+    user.profile.unlocked_levels.filter(level__gt=reset_to_level).delete()
     user.profile.save()
 
 
@@ -344,7 +344,7 @@ def reset_reviews(user, reset_to_level):
         f"{user.username} is having their reviews cleared cleared down to level {reset_to_level}"
     )
     reviews_to_delete = UserSpecific.objects.filter(user=user)
-    reviews_to_delete = reviews_to_delete.exclude(
-        vocabulary__readings__level__lt=reset_to_level
+    reviews_to_delete = reviews_to_delete.filter(
+        vocabulary__readings__level__gt=reset_to_level
     )
     reviews_to_delete.delete()

--- a/kw_webapp/tests/test_tasks.py
+++ b/kw_webapp/tests/test_tasks.py
@@ -205,7 +205,7 @@ class TestTasks(TestCase):
         )
         reset_levels(self.user, 1)
         self.user.refresh_from_db()
-        self.assertListEqual(self.user.profile.unlocked_levels_list(), [])
+        self.assertListEqual(self.user.profile.unlocked_levels_list(), [1])
 
     @responses.activate
     def test_when_user_resets_their_account_we_remove_all_reviews_and_then_unlock_their_current_level(


### PR DESCRIPTION
## Overview
This change changes the /user/reset mutation to reset the user's levels and reviews TO the specified level, rather than including the requested level in those being reset. This allows for slightly clearer wording from the front-end, maybe avoiding resets of a level users don't expect.

## Testing
A couple of tests were reworked in light of this change, and this was tested locally - resets to level e.g. 4 do not reset open reviews or levels for Vocab of level 4, but are when reset to level 3.

A corresponding PR for the front-end changes is [here](https://github.com/Kaniwani/kw-frontend/pull/111)