### PR TITLE
Update `DATABASE_URL` to `db` instead of `localhost`

### DIFF
--- a/KW/.env
+++ b/KW/.env
@@ -5,7 +5,7 @@ CORS_ORIGIN_WHITELIST=localhost:3000,http://localhost:3000/,http://127.0.0.1:300
 SECRET_KEY=donteventryitdonteventryitdonteventryitdonteventryit
 
 # This is defined in the docker-compose.yml and should not be used in production
-DATABASE_URL=psql://kaniwani:password@localhost:5432/kaniwani
+DATABASE_URL=psql://kaniwani:password@db:5432/kaniwani
 #DATABASE_URL=sqlite:////tmp/my-tmp-sqlite.db
 
 # This is defined in the Docker/redis/redis.conf and should not be used in production


### PR DESCRIPTION
This merge request is about updating the `DATABASE_URL` variable from the `KW/.env` file to be able to access the `db` container from the backend one.

While installing the devstack, my backend container was not able to reach the `db` one because the `DATABASE_URL` variable was not set properly. So I updated it to use the Docker host alias `db` instead of `localhost`. 